### PR TITLE
Task.7-1 記事に関するAPIのルーティングの実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api, format: :json do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+    end
+  end
 end


### PR DESCRIPTION
## 作業概要
APIのendpointを/api/v1 から始まるようにルーティングを設定

## 作業詳細
- routes.rbを修正